### PR TITLE
Allow s-maxage to be parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,17 +21,24 @@ module.exports = function parseCacheControl(field) {
     return '';
   });
 
-  if (header['max-age']) {
-    try {
-      var maxAge = parseInt(header['max-age'], 10);
-      if (isNaN(maxAge)) {
-        return null;
-      }
+  var numbers = [
+    'max-age',
+    's-maxage'
+  ];
 
-      header['max-age'] = maxAge;
-    }
-    catch (err) { }
-  }
+  numbers
+    .filter(function (key) { return header[key]; })
+    .forEach(function (key) {
+      try {
+        var maxAge = parseInt(header[key], 10);
+        if (isNaN(maxAge)) {
+          err = 'Cache-Control['+key+'] parsed but is not a number';
+        }
+        header[key] = maxAge;
+      } catch (e) {
+        err = 'Cache-Control['+key+'] not parseable';
+      }
+    });
 
   return (err ? null : header);
 };


### PR DESCRIPTION
max-age and s-maxage serve the same purpose and work the same way. The order of priority is as follow:
- First priority on s-maxage
- Then on max-age
- Then on expires

Here is the RFC regarding the s-maxage:
https://tools.ietf.org/html/rfc7234#section-5.2.2.9
